### PR TITLE
feat:投稿、TDN画面更新。ホーム画面にユーザー名表示。

### DIFF
--- a/app/(pages)/episodes/page.tsx
+++ b/app/(pages)/episodes/page.tsx
@@ -1,8 +1,90 @@
-export default function EpisodesPage() {
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import PostForm from '../../_components/ui/PostForm';
+import LikeButton from '../../_components/ui/LikeButton';
+
+export default async function EpisodesPage() {
+  const supabase = createServerComponentClient({ cookies });
+  const { data: { session } } = await supabase.auth.getSession();
+  const userId = session?.user?.id;
+
+  // ログインユーザーの情報を取得
+  const currentUser = userId ? await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true }
+  }) : null;
+
+  // 自分の投稿のみを取得
+  const myEpisodes = userId ? await prisma.episode.findMany({
+    where: { user_id: userId },
+    orderBy: { created_at: 'desc' },
+    include: {
+      user: { select: { name: true } },
+      _count: { select: { likes: true } },
+      likes: { where: { user_id: userId }, select: { user_id: true } },
+    },
+  }) : [];
+
   return (
     <div style={{ padding: 16 }}>
-      <h1>エピソード投稿ページ</h1>
-      <p>エピソード投稿機能を実装します。</p>
+      <h1>ダメ人間エピソード投稿</h1>
+
+      {session ? (
+        <div>
+          <p>投稿者: {currentUser?.name || session.user.email}</p>
+          <PostForm />
+        </div>
+      ) : (
+        <div>
+          <p>投稿するにはログインが必要です。</p>
+          <Link href="/login" style={{ color: 'blue', textDecoration: 'underline' }}>
+            ログインページへ
+          </Link>
+        </div>
+      )}
+
+      {/* 自分の投稿一覧 */}
+      {session && (
+        <div style={{ marginTop: 40 }}>
+          <h2>あなたの投稿</h2>
+          {myEpisodes.length > 0 ? (
+            myEpisodes.map((episode) => (
+              <div key={episode.id} style={{ 
+                border: '1px solid #e1e8ed', 
+                padding: 16, 
+                marginBottom: 12, 
+                borderRadius: 8,
+                backgroundColor: '#fff',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.1)'
+              }}>
+                <div style={{ marginBottom: 12 }}>
+                  <p style={{ margin: 0, fontSize: '16px', lineHeight: '1.4' }}>{episode.content}</p>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', color: '#657786', fontSize: '14px' }}>
+                  <span>{new Date(episode.created_at).toLocaleString()}</span>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                    <span>❤️ {episode._count.likes}</span>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div style={{ 
+              border: '1px dashed #ccc', 
+              padding: 20, 
+              textAlign: 'center', 
+              borderRadius: 8,
+              backgroundColor: '#f9f9f9',
+              color: '#666'
+            }}>
+              <p>まだ投稿がありません</p>
+              <p>上のフォームから最初の投稿をしてみましょう！</p>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(pages)/tdn/page.tsx
+++ b/app/(pages)/tdn/page.tsx
@@ -1,8 +1,77 @@
-export default function TdnPage() {
+import { prisma } from '@/lib/prisma';
+
+// TDNのデータを取得する関数
+async function getTdn() {
+  try {
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const topLikes = await prisma.like.groupBy({
+      by: ['episode_id'],
+      where: {
+        created_at: { gte: twentyFourHoursAgo },
+      },
+      _count: { episode_id: true },
+      orderBy: { _count: { episode_id: 'desc' } },
+      take: 1,
+    });
+
+    if (topLikes.length === 0) {
+      // 24時間以内のいいねがない場合、全ての期間でトップの投稿を探す
+      const allTimeTop = await prisma.episode.findFirst({
+        orderBy: {
+          likes: {
+            _count: 'desc',
+          },
+        },
+        include: {
+          user: { select: { name: true } },
+          _count: { select: { likes: true } },
+        },
+      });
+      return allTimeTop;
+    }
+
+    const tdnEpisode = await prisma.episode.findUnique({
+      where: { id: topLikes[0].episode_id },
+      include: {
+        user: { select: { name: true } },
+        _count: { select: { likes: true } },
+      },
+    });
+    return tdnEpisode;
+  } catch (error) {
+    console.error('Failed to fetch TDN:', error);
+    return null;
+  }
+}
+
+export default async function TdnPage() {
+  const tdn = await getTdn();
+
   return (
     <div style={{ padding: 16 }}>
-      <h1>今日のダメ人間 (TDN)</h1>
-      <p>TDN表示機能を実装します。</p>
+      <h1>👑 今日のダメ人間 (TDN) 👑</h1>
+      
+      {tdn ? (
+        <div style={{ border: '2px solid gold', backgroundColor: '#fffacd', padding: 20, borderRadius: 8, margin: '20px 0' }}>
+          <h2 style={{ marginTop: 0, color: '#b8860b' }}>{tdn.content}</h2>
+          <div style={{ marginTop: 15 }}>
+            <p><strong>投稿者:</strong> {tdn.user?.name || '名無しさん'}</p>
+            <p><strong>いいね数:</strong> {tdn._count.likes}</p>
+            <p><strong>投稿日時:</strong> {new Date(tdn.created_at).toLocaleString()}</p>
+          </div>
+        </div>
+      ) : (
+        <div style={{ border: '1px solid #ccc', padding: 20, borderRadius: 8, backgroundColor: '#f9f9f9' }}>
+          <p>今日のダメ人間はまだいません。</p>
+          <p>あなたが初代TDNになるチャンス！</p>
+        </div>
+      )}
+      
+      <div style={{ marginTop: 30, textAlign: 'center' }}>
+        <p style={{ color: '#666', fontSize: '14px' }}>
+          TDNは24時間以内に最もいいねを獲得したエピソードです
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,6 +54,12 @@ export default async function HomePage() {
   const { data: { session } } = await supabase.auth.getSession();
   const userId = session?.user?.id;
 
+  // ログインユーザーの情報を取得
+  const currentUser = userId ? await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true }
+  }) : null;
+
   // サーバーサイドでエピソード一覧とTDNを並行して取得
   const [episodes, tdn] = await Promise.all([
     prisma.episode.findMany({
@@ -90,18 +96,27 @@ export default async function HomePage() {
         ) : (
           <p>今日のダメ人間はまだいません。あなたが初代TDNになるチャンス！</p>
         )}
+        <div style={{ marginTop: '15px' }}>
+          <Link href="/tdn" style={{ color: '#b8860b', textDecoration: 'underline' }}>
+            詳細を見る
+          </Link>
+        </div>
       </div>
 
       {/* ログイン状態による表示切り替え */}
       {session ? (
         <div>
-          <p>ようこそ、{session.user.email} さん</p>
-          <form action="/api/auth/logout" method="post" style={{ display: 'inline', marginLeft: '20px' }}>
+          <p>ようこそ、{currentUser?.name || session.user.email} さん</p>
+          <form action="/login" method="post" style={{ display: 'inline', marginLeft: '20px' }}>
             <button type="submit" style={{ background: '#dc3545', color: '#fff', border: 'none', padding: '6px 16px', borderRadius: '4px', cursor: 'pointer' }}>
               ログアウト
             </button>
           </form>
-          <PostForm />
+          <div style={{ marginTop: '20px' }}>
+            <Link href="/episodes" style={{ color: 'blue', textDecoration: 'underline' }}>
+              エピソードを投稿する
+            </Link>
+          </div>
         </div>
       ) : (
         <div>


### PR DESCRIPTION
## 概要
- ホーム画面にダメ人間エピソード投稿画面とTDNが表示されていたのでそれぞれの遷移先の画面で表示。
- 投稿画面には自分が投稿した内容を表示。
- ホーム画面のようこそ○○の○○はメールアドレスだったのをユーザー名に変更

## 変更点
- [ ]

## 動作確認手順
```powershell
# 例
npx prisma generate
npx prisma db push
```

## 影響範囲
- [ ] 本番データベース
- [ ] 環境変数 / 設定
- [ ] 依存パッケージ

## チェックリスト
- [ ] センシティブ情報が混入していない（鍵/パスワード/個人情報）
- [ ] ESLint・型チェックが通る
- [ ] 受入基準を満たす

## 関連Issue
Closes #
